### PR TITLE
x11: Bind X authority file if the `XAUTHORITY` env var is set

### DIFF
--- a/global.yml
+++ b/global.yml
@@ -90,6 +90,10 @@ rules:
       - DISPLAY
       - env: DISPLAY
       - bind: /tmp/.X11-unix/
+    - ifdef:
+      - XAUTHORITY
+      - env: XAUTHORITY
+      - bind: $XAUTHORITY
 
   wayland:
     - Allow access to Wayland.


### PR DESCRIPTION
Without access to the X authority file, GUI programs will fail to launch in X11 sessions. For example, here's what we get when trying to launch IDA (a Qt 5 program):

```
$ sbx run ida
Authorization required, but no authorization protocol specified

qt.qpa.xcb: could not connect to display :0
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-glx, xcb.
```

Now, we bind the X authority file (presumably) that's set in the `XAUTHORITY` environment variable, making it available inside the sandbox.