### PR TITLE
Set the correct permissions for `XDG_RUNTIME_DIR`

### DIFF
--- a/global.yml
+++ b/global.yml
@@ -29,7 +29,7 @@ rules:
     - bind: /usr/include
     - symlink: [usr/bin, /bin]
     - symlink: [usr/bin, /sbin]
-    - tmpfs: $XDG_RUNTIME_DIR
+    - tmpfs: {path: $XDG_RUNTIME_DIR, perms: 0o700}
     - file: $XDG_RUNTIME_DIR/flatpak-info
     - file: /.flatpak-info
     - bind: {path: /run/systemd/resolve, try: true}


### PR DESCRIPTION
From the [XDG Base Directory Specification (version 0.8)](https://specifications.freedesktop.org/basedir-spec/0.8/#variables:~:text=should%20be%20used.-,%24XDG_RUNTIME_DIR,write%20access%20to%20it.%20Its%20Unix%20access%20mode%20MUST%20be%200700.,-The%20lifetime%20of):

>`$XDG_RUNTIME_DIR` defines the base directory relative to which user-specific non-essential runtime files and other file objects (such as sockets, named pipes, ...) should be stored. The directory MUST be owned by the user, and they MUST be the only one having read and write access to it. Its Unix access mode MUST be 0700.