### PR TITLE
Follow the XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ rules:
         create: skel
     - dir: $HOME/.config
     - dir: $HOME/.cache
-    - dir: $HOME.local/share
+    - dir: $HOME/.local/share
 ```
 
 The above rule creates a private home directory with several subdirectories.

--- a/sbx
+++ b/sbx
@@ -13,8 +13,11 @@ import random
 from functools import reduce
 
 
-SANDBOX_ROOT   = '$HOME/.config/sandbubble'
-SANDBOX_HOME   = '$HOME/.local/share/sandbubble/$SANDBOX'
+XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME', '$HOME/.config')
+XDG_DATA_HOME   = os.environ.get('XDG_DATA_HOME', '$HOME/.local/share')
+
+SANDBOX_ROOT   = f'{XDG_CONFIG_HOME}/sandbubble'
+SANDBOX_HOME   = f'{XDG_DATA_HOME}/sandbubble/$SANDBOX'
 SANDBOX_CONFIG = f'{SANDBOX_ROOT}/$SANDBOX/config.yml'
 DEFAULT_CONFIG = f'{SANDBOX_ROOT}/global.yml'
 APP_BASE       = 'org.sandbubble'


### PR DESCRIPTION
This essentially:

- Tries to use `$XDG_CONFIG_HOME` if set, otherwise use `~/.config`
- Tries to use `$XDG_DATA_HOME` if set, otherwise use `~/.local/share`

See: https://specifications.freedesktop.org/basedir-spec/0.8/#variables